### PR TITLE
Removed: ip = self.get_argument('ip')

### DIFF
--- a/pytt/tracker.py
+++ b/pytt/tracker.py
@@ -34,7 +34,7 @@ class AnnounceHandler(BaseHandler):
         # get all the required parameters from the HTTP request.
         info_hash = self.get_argument('info_hash')
         peer_id = self.get_argument('peer_id')
-        ip = self.get_argument('ip') or self.request.remote_ip
+        ip = self.request.remote_ip
         port = self.get_argument('port')
 
         # send appropirate error code.


### PR DESCRIPTION
Why should we trust http parameter "ip"? This just lead to peers being able to spam our database with fake peers. The peer creating the http request is the peer we want to add to our database (not some arbitrary value).
