### PR TITLE
Changed sys.version to sys.version_info in pytt/bencode.py

### DIFF
--- a/pytt/bencode.py
+++ b/pytt/bencode.py
@@ -175,7 +175,7 @@ decode_func = {
 }
 
 
-if sys.version >= (3, 0):
+if sys.version_info >= (3, 0):
     encode_func[bytes] = encode_string
 
     def translate(value):


### PR DESCRIPTION
Changed sys.version to sys.version_info, the former returns a string that can't be compared to a tuple.
